### PR TITLE
Fix Astro deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [ dev ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflow to trigger on `dev` branch instead of `main`
- This resolves the Astro deployment issue where GitHub was trying to build with Jekyll

## Problem
GitHub Pages was failing to deploy because:
1. Workflow was set to trigger on `main` branch but site deploys from `dev` 
2. Without proper workflow, GitHub defaulted to Jekyll build which fails for Astro

## Solution
- Updated `.github/workflows/deploy.yml` to trigger on `dev` branch pushes
- This ensures the Astro build action runs correctly

## Test plan
- [x] Updated workflow configuration
- [ ] Test deployment after merge

🤖 Generated with [Claude Code](https://claude.ai/code)