### PR TITLE
Increase About Me box opacity for better desktop readability

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -916,7 +916,7 @@
         display: block;
         overflow-y: scroll;
         z-index: 10000;
-        background: rgba(255, 255, 255, 0.4);
+        background: rgba(255, 255, 255, 0.95);
         backdrop-filter: blur(10px);
         border: 2px solid rgba(255, 255, 255, 0.3);
         opacity: 1;


### PR DESCRIPTION
## Summary
- Increased the opacity of the expanded About Me box from 40% to 95% on desktop
- Now matches the mobile experience for consistency across devices
- Improves text visibility and readability on larger screens

## Changes
- Modified `#aboutContent.expanded` background from `rgba(255, 255, 255, 0.4)` to `rgba(255, 255, 255, 0.95)`

## Test plan
- [ ] Open website locally and click "About Me" on desktop
- [ ] Verify the box is more opaque and text is more readable
- [ ] Check mobile/iPhone to confirm opacity matches
- [ ] Verify the change looks good on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)